### PR TITLE
Add puppet to playdoh

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,43 @@
+require "yaml"
+
+# Load up our vagrant config files -- vagrantconfig.yaml first
+_config = YAML.load(File.open(File.join(File.dirname(__FILE__),
+                    "vagrantconfig.yaml"), File::RDONLY).read)
+
+# Local-specific/not-git-managed config -- vagrantconfig_local.yaml
+begin
+    _config.merge!(YAML.load(File.open(File.join(File.dirname(__FILE__),
+                   "vagrantconfig_local.yaml"), File::RDONLY).read))
+rescue Errno::ENOENT # No vagrantconfig_local.yaml found -- that's OK; just
+                     # use the defaults.
+end
+
+CONF = _config
+MOUNT_POINT = '/home/vagrant/project'
+
+Vagrant::Config.run do |config|
+    config.vm.box = "lucid32"
+    config.vm.box_url = "http://files.vagrantup.com/lucid32.box"
+
+    config.vm.forward_port("web", 8000, 8000)
+
+    # Increase vagrant's patience during hang-y CentOS bootup
+    # see: https://github.com/jedi4ever/veewee/issues/14
+    config.ssh.max_tries = 50
+    config.ssh.timeout   = 300
+
+    # nfs needs to be explicitly enabled to run.
+    if CONF['nfs'] == false or RUBY_PLATFORM =~ /mswin(32|64)/
+        config.vm.share_folder("v-root", MOUNT_POINT, ".")
+    else
+        config.vm.share_folder("v-root", MOUNT_POINT, ".", :nfs => true)
+    end
+
+    # Add to /etc/hosts: 33.33.33.24 dev.playdoh.org
+    config.vm.network "33.33.33.24"
+
+    config.vm.provision :puppet do |puppet|
+        puppet.manifests_path = "puppet/manifests"
+        puppet.manifest_file  = "vagrant.pp"
+    end
+end

--- a/puppet/files/etc/httpd/conf.d/playdoh.conf
+++ b/puppet/files/etc/httpd/conf.d/playdoh.conf
@@ -1,0 +1,30 @@
+# HACK: Make the server reload after every hit to refresh django code
+MaxRequestsPerChild 1
+
+WSGISocketPrefix /var/run/wsgi
+
+<VirtualHost *:443 *:80>
+    ServerName dev.playdoh.org
+
+    DirectoryIndex index.php index.html
+    Options -Indexes
+
+    RewriteEngine On
+
+    DocumentRoot "/var/www/html/"
+
+    Alias /media/ "/home/vagrant/project/media/"
+    Alias /admin-media/ "/home/vagrant/project/vendor/src/django/django/contrib/admin/media/"
+
+    WSGIDaemonProcess playdoh processes=1 threads=1 maximum-requests=1
+    WSGIProcessGroup playdoh
+
+    WSGIScriptAlias / "/home/vagrant/project/wsgi/playdoh.wsgi"
+
+    <Proxy *>
+        AddDefaultCharset off
+        Order deny,allow
+        Deny from all
+        Allow from all
+    </Proxy>
+</VirtualHost>

--- a/puppet/manifests/classes/apache.pp
+++ b/puppet/manifests/classes/apache.pp
@@ -1,0 +1,53 @@
+# Red Hat, CentOS, and Fedora think Apache is the only web server
+# ever, so we have to use a different package on CentOS than Ubuntu.
+class apache {
+    case $operatingsystem {
+        centos: {
+            package { "httpd-devel":
+                ensure => present,
+                before => File['/etc/httpd/conf.d/playdoh.conf'];
+            }
+
+            file { "/etc/httpd/conf.d/playdoh.conf":
+                source => "$PROJ_DIR/puppet/files/etc/httpd/conf.d/playdoh.conf",
+                owner => "root", group => "root", mode => 0644,
+                require => [
+                    Package['httpd-devel']
+                ];
+            }
+
+            service { "httpd":
+                ensure => running,
+                enable => true,
+                require => [
+                    Package['httpd-devel'],
+                    File['/etc/httpd/conf.d/playdoh.conf']
+                ];
+            }
+
+        }
+        ubuntu: {
+            package { "apache2-dev":
+                ensure => present,
+                before => File['/etc/apache2/sites-enabled/playdoh.conf']; 
+            }
+
+            file { "/etc/apache2/sites-enabled/playdoh.conf":
+                source => "$PROJ_DIR/puppet/files/etc/httpd/conf.d/playdoh.conf",
+                owner => "root", group => "root", mode => 0644,
+                require => [
+                    Package['apache2-dev']
+                ];
+            }
+
+            service { "apache2":
+                ensure => running,
+                enable => true,
+                require => [
+                    Package['apache2-dev'],
+                    File['/etc/apache2/sites-enabled/playdoh.conf']
+                ];
+            }
+        }
+    }
+}

--- a/puppet/manifests/classes/custom.pp
+++ b/puppet/manifests/classes/custom.pp
@@ -1,0 +1,3 @@
+# You can add custom puppet manifests for your app here.
+class custom {
+}

--- a/puppet/manifests/classes/init.pp
+++ b/puppet/manifests/classes/init.pp
@@ -1,0 +1,16 @@
+# stage {"pre": before => Stage["main"]} class {'apt': stage => 'pre'}
+
+# Commands to run before all others in puppet.
+class init {
+    group { "puppet":
+        ensure => "present",
+    }
+
+    case $operatingsystem {
+        ubuntu: {
+            exec { "update_apt":
+                command => "/usr/bin/sudo /usr/bin/apt-get update",
+            }
+        }
+    }
+}

--- a/puppet/manifests/classes/memcahed.pp
+++ b/puppet/manifests/classes/memcahed.pp
@@ -1,0 +1,14 @@
+# We use memcached in production, so we _should_ use it while
+# we develop as well. That said, playdoh shouldn't *rely* on it
+# entirely; it should work with any non-null cache store in Django.
+class memcached {
+    package { "memcached":
+        ensure => installed;
+    }
+
+    service { "memcached":
+        ensure => running,
+        enable => true,
+        require => Package['memcached'];
+    }
+}

--- a/puppet/manifests/classes/mysql.pp
+++ b/puppet/manifests/classes/mysql.pp
@@ -1,0 +1,26 @@
+# Get mysql up and running
+class mysql {
+    package { "mysql-server":
+        ensure => installed;
+    }
+
+    case $operatingsystem {
+        centos: {
+            package { "mysql-devel":
+                ensure => installed;
+            }
+        }
+
+        ubuntu: {
+            package { "libmysqld-dev":
+                ensure => installed;
+            }
+        }
+    }
+
+    service { "mysql":
+        ensure => running,
+        enable => true,
+        require => Package['mysql-server'];
+    }
+}

--- a/puppet/manifests/classes/playdoh.pp
+++ b/puppet/manifests/classes/playdoh.pp
@@ -1,0 +1,32 @@
+# playdoh-specific commands that get playdoh all going so you don't
+# have to.
+
+# TODO: Make this rely on things that are not straight-up exec.
+class playdoh {
+    exec { "create_mysql_database":
+        command => "/usr/bin/mysqladmin -uroot create $DB_NAME",
+        unless  => "/usr/bin/mysql -uroot -B --skip-column-names -e 'show databases' | /bin/grep '$DB_NAME'",
+    }
+
+    exec { "grant_mysql_database":
+        command => "/usr/bin/mysql -uroot -B -e'GRANT ALL PRIVILEGES ON $DB_NAME.* TO $DB_USER@localhost # IDENTIFIED BY \"$DB_PASS\"'",
+        unless  => "/usr/bin/mysql -uroot -B --skip-column-names mysql -e 'select user from user' | /bin/grep '$DB_USER'",
+        require => Exec["create_mysql_database"];
+    }
+
+    exec { "syncdb":
+        cwd => "$PROJ_DIR",
+        command => "/usr/bin/python2.6 ./manage.py syncdb --noinput",
+        require => Exec["grant_mysql_database"];
+    }
+
+    exec { "sql_migrate":
+        cwd => "$PROJ_DIR",
+        command => "/usr/bin/python2.6 ./vendor/src/schematic/schematic migrations/",
+        require => [
+            Service["mysql"],
+            Package["python2.6-dev", "libapache2-mod-wsgi", "python-wsgi-intercept" ],
+            Exec["syncdb"]
+        ];
+    }
+}

--- a/puppet/manifests/classes/python.pp
+++ b/puppet/manifests/classes/python.pp
@@ -1,0 +1,34 @@
+# Install python and compiled modules for project
+class python {
+    case $operatingsystem {
+        centos: {
+            package {
+                [ "python26-devel", "python26-libs", "python26-distribute", "python26-mod_wsgi" ]:
+                    ensure => installed;
+            }
+
+            exec { "pip-install":
+                command => "/usr/bin/easy_install-2.6 -U pip",
+                creates => "/usr/bin/pip",
+                require => Package["python26-devel","python26-distribute"]
+            }
+
+            exec { "pip-install-compiled":
+                command => "/usr/bin/pip install -r $PROJ_DIR/requirements/compiled.txt",
+                require => Exec['pip-install']
+            }
+        }
+
+        ubuntu: {
+            package {
+                [ "python2.6-dev", "python2.6", "libapache2-mod-wsgi", "python-wsgi-intercept", "python-pip" ]:
+                    ensure => installed;
+            }
+
+            exec { "pip-install-compiled":
+                command => "/usr/bin/pip install -r $PROJ_DIR/requirements/compiled.txt",
+                require => Package['python-pip']
+            }
+        }
+    }
+}

--- a/puppet/manifests/vagrant.pp
+++ b/puppet/manifests/vagrant.pp
@@ -1,0 +1,25 @@
+#
+# Playdoh puppet magic for dev boxes
+#
+import "classes/*.pp"
+
+$PROJ_DIR = "/home/vagrant/project"
+
+# You can make these less generic if you like, but these are box-specific
+# so it's not required.
+$DB_NAME = "playdoh_app"
+$DB_USER = "root"
+
+class dev {
+    class {
+        init: before => Class[mysql];
+        mysql: before  => Class[python];
+        python: before => Class[apache];
+        apache: before => Class[playdoh];
+        memcached: ;
+        playdoh: ;
+        custom: ;
+    }
+}
+
+include dev

--- a/settings_local.py-dist
+++ b/settings_local.py-dist
@@ -7,8 +7,8 @@ from settings import *
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.mysql',
-        'NAME': '',
-        'USER': '',
+        'NAME': 'playdoh_app',
+        'USER': 'root',
         'PASSWORD': '',
         'HOST': '',
         'PORT': '',

--- a/vagrantconfig.yaml
+++ b/vagrantconfig.yaml
@@ -1,0 +1,5 @@
+# Default config for Vagrant
+
+# Don't change this; use vagrantconfig_local.yaml to override these
+# settings instead.
+nfs: false

--- a/vagrantconfig_local.yaml-dist
+++ b/vagrantconfig_local.yaml-dist
@@ -1,0 +1,5 @@
+# Configuration for Vagrant
+
+# Change to true if you can use nfs; using nfs significantly
+# improves performance.
+nfs: false


### PR DESCRIPTION
Yo dawg I heard you liked developing so I developed a development VM.

This is just a start, but what say you playdoh-folks? I'd like us to extract, based on usage, what we need in a VM and probably eventually customize the box (especially to avoid the install/network requests puppet currently goes through), but this is the start of vagrant/puppet for playdoh.

We could move the vagrantconfig files out of the root directory when we move settings into its own folder/module too, if you like.
