### PR TITLE
Adding DJANGO_SETTINGS_MODULE to playdoh.wsgi

### DIFF
--- a/wsgi/playdoh.wsgi
+++ b/wsgi/playdoh.wsgi
@@ -11,6 +11,7 @@ site.addsitedir(os.path.abspath(os.path.join(wsgidir, '../')))
 import manage
 
 import django.core.handlers.wsgi
+os.environ['DJANGO_SETTINGS_MODULE'] = 'settings'
 application = django.core.handlers.wsgi.WSGIHandler()
 
 # vim: ft=python


### PR DESCRIPTION
When no longer "hard coding" use of `setup_environ()` we need to make sure the `DJANGO_SETTINGS_MODULE` is correctly configured when doing mod_wsgi.

This pull request solves...
https://github.com/mozilla/playdoh/issues/82

and is related directory to...
https://github.com/mozilla/funfactory/pull/18
