### PR TITLE
Changes to make Vagrantfile compatible with vagrant 0.9.x

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,7 +19,7 @@ Vagrant::Config.run do |config|
     config.vm.box = "lucid32"
     config.vm.box_url = "http://files.vagrantup.com/lucid32.box"
 
-    config.vm.forward_port("web", 8000, 8000)
+    config.vm.forward_port 8000, 8000
 
     # Increase vagrant's patience during hang-y CentOS bootup
     # see: https://github.com/jedi4ever/veewee/issues/14
@@ -34,7 +34,7 @@ Vagrant::Config.run do |config|
     end
 
     # Add to /etc/hosts: 33.33.33.24 dev.playdoh.org
-    config.vm.network "33.33.33.24"
+    config.vm.network :hostonly, "33.33.33.24"
 
     config.vm.provision :puppet do |puppet|
         puppet.manifests_path = "puppet/manifests"


### PR DESCRIPTION
Recent version of vagrant (0.9.x) has backwards incompatibilities with Vagrantfile syntax for 0.8.x
These changes fix this. Ultimately vagrant (1.x onwards) will stick to syntax of 0.9.x
More here: http://vagrantup.com/docs/changes/changes_08x_09x.html
