### PR TITLE
Add project/ to path for settings files.

### DIFF
--- a/puppet/manifests/classes/playdoh.pp
+++ b/puppet/manifests/classes/playdoh.pp
@@ -3,16 +3,16 @@
 
 # TODO: Make this rely on things that are not straight-up exec.
 class playdoh {
-    file { "$PROJ_DIR/settings/local.py":
+    file { "$PROJ_DIR/project/settings/local.py":
         ensure => file,
-        source => "$PROJ_DIR/settings/local.py-dist",
+        source => "$PROJ_DIR/project/settings/local.py-dist",
         replace => false;
     }
 
     exec { "create_mysql_database":
         command => "mysql -uroot -B -e'CREATE DATABASE $DB_NAME CHARACTER SET utf8;'",
         unless  => "mysql -uroot -B --skip-column-names -e 'show databases' | /bin/grep '$DB_NAME'",
-        require => File["$PROJ_DIR/settings/local.py"]
+        require => File["$PROJ_DIR/project/settings/local.py"]
     }
 
     exec { "grant_mysql_database":


### PR DESCRIPTION
Puppet was looking in the wrong location for the project's settings files.
Adding project/ to the path fixes this problem and allows 'vagrant up' on
a fresh clone of playdoh to be successful.
