### PR TITLE
Add 'registration' to JINGO_EXCLUDE_APPS

### DIFF
--- a/project/settings/base.py
+++ b/project/settings/base.py
@@ -38,6 +38,7 @@ INSTALLED_APPS = list(INSTALLED_APPS) + [
 # apps here:
 JINGO_EXCLUDE_APPS = [
     'admin',
+    'registration',
 ]
 
 # Tells the extract script what files to look for L10n in and what function


### PR DESCRIPTION
When you logout from the Django admin, "TemplateSyntaxError at /admin/logout/" is thrown (Encountered unknown tag 'load'.).
