### PR TITLE
BrowserID support (issue 73)

### DIFF
--- a/project/examples/models.py
+++ b/project/examples/models.py
@@ -1,0 +1,8 @@
+from django.contrib.auth.models import User
+
+
+# User class extensions
+def user_unicode(self):
+    """Use email address for string representation of user."""
+    return self.email
+User.add_to_class('__unicode__', user_unicode)

--- a/project/examples/templates/examples/home.html
+++ b/project/examples/templates/examples/home.html
@@ -5,6 +5,17 @@
     <a href="/">{{ _('Hello world') }}</a>
 </h1>
 
+{% if request.user.is_active %}
+    <p>{{ _('You are logged in as {username}')|f(username=request.user) }}.
+    <a href="{{ url('examples.logout') }}">{{ _('Log out') }}</a></p>
+{% else %}
+    <p><a id="browserid" href="#">{{ _('Log in with BrowserID') }}</a></p>
+    <form method="POST" action="{{ url('browserid_verify') }}">
+        {{ csrf() }}
+        {{ browserid_form.as_p() }}
+    </form>
+{% endif %}
+
 {# L10n: This is a localizer comment #}
 {% if request.MOBILE %}
   <p>{{ _('This is a <em>test view</em> for mobile browsers.') }}</p>
@@ -15,7 +26,7 @@
   {% trans docs_url='http://playdoh.rtfd.org/' %}
   <a href="{{ docs_url }}">Learn you some Playdoh</a> and then go build
   something <strong>awesome</strong>.
-  {% endtrans %}  
+  {% endtrans %}
 </p>
 <p>
   {% trans langs=LANGUAGES.items() %}
@@ -27,4 +38,10 @@
 <ul>
   <li><a href="{{ url('examples.bleach') }}">Input sanitization with Bleach</a></li>
 </ul>
+{% endblock %}
+{% block site_js %}
+    {{ js('example_js') }}
+    {% if not request.user.is_active %}
+        {{ browserid_form.media }}
+    {% endif %}
 {% endblock %}

--- a/project/examples/urls.py
+++ b/project/examples/urls.py
@@ -5,5 +5,8 @@ from . import views
 
 urlpatterns = patterns('',
     url(r'^$', views.home, name='examples.home'),
+    url(r'^browserid/', include('django_browserid.urls')),
+    url(r'^logout/?$', 'django.contrib.auth.views.logout', {'next_page': '/'},
+        name='examples.logout'),
     url(r'^bleach/?$', views.bleach_test, name='examples.bleach'),
 )

--- a/project/examples/views.py
+++ b/project/examples/views.py
@@ -2,7 +2,6 @@
 
 import logging
 
-from django import http
 from django.shortcuts import render
 
 import bleach

--- a/project/settings/base.py
+++ b/project/settings/base.py
@@ -47,6 +47,24 @@ JINGO_EXCLUDE_APPS = [
     'registration',
 ]
 
+# BrowserID configuration
+AUTHENTICATION_BACKENDS = [
+    'django_browserid.auth.BrowserIDBackend',
+    'django.contrib.auth.backends.ModelBackend',
+]
+
+SITE_URL = 'http://127.0.0.1:8000'
+LOGIN_URL = '/'
+LOGIN_REDIRECT_URL = 'examples.home'
+LOGIN_REDIRECT_URL_FAILURE = 'examples.home'
+
+TEMPLATE_CONTEXT_PROCESSORS = list(TEMPLATE_CONTEXT_PROCESSORS) + [
+    'django_browserid.context_processors.browserid_form',
+]
+
+# Always generate a CSRF token for anonymous users.
+ANON_ALWAYS = True
+
 # Tells the extract script what files to look for L10n in and what function
 # handles the extraction. The Tower library expects this.
 DOMAIN_METHODS['messages'] = [

--- a/project/settings/local.py-dist
+++ b/project/settings/local.py-dist
@@ -43,6 +43,10 @@ DEBUG = TEMPLATE_DEBUG = True
 # instances and False on stage/prod.
 DEV = True
 
+# By default, BrowserID expects your app to use http://127.0.0.1:8000
+# Uncomment the following line if you prefer to access your app via localhost
+# SITE_URL = 'http://localhost:8000'
+
 # # Playdoh ships with sha512 password hashing by default. Bcrypt+HMAC is safer,
 # # so it is recommended. Please read <https://github.com/fwenzel/django-sha2#readme>,
 # # uncomment the bcrypt hasher and pick a secret HMAC key for your application.


### PR DESCRIPTION
Provides basic BrowserID support via django-browserid, including example authentication flow in the examples app. Requires https://github.com/mozilla/funfactory/pull/29
