### PR TITLE
Add a commented line that disables secure cookies.

### DIFF
--- a/project/settings/local.py-dist
+++ b/project/settings/local.py-dist
@@ -77,3 +77,7 @@ SECRET_KEY = ''
 # Common Event Format logging parameters
 #CEF_PRODUCT = 'Playdoh'
 #CEF_VENDOR = 'Mozilla'
+
+# Uncomment this line if you are running a local development install without
+# HTTPS to disable HTTPS-only cookies.
+#SESSION_COOKIE_SECURE = False


### PR DESCRIPTION
Most local development installs don't use HTTPS, which means they
need to disable secure cookies in order to use cookies at all

I decided to use a commented line as opposed to disabling them by
default out of fear that they would end up disabled by accident on
the server.
