### PR TITLE
Specify LOCALE_PATHS to remove DeprecationWarning

### DIFF
--- a/project/settings/base.py
+++ b/project/settings/base.py
@@ -19,6 +19,9 @@ INSTALLED_APPS = list(INSTALLED_APPS) + [
     '%s.examples' % PROJECT_MODULE,
 ]
 
+LOCALE_PATHS = (
+    os.path.join(ROOT, PROJECT_MODULE, 'locale'),
+)
 
 # Because Jinja2 is the default template loader, add any non-Jinja templated
 # apps here:


### PR DESCRIPTION
Currently, `./manage.py runserver` gives the following warning twice:

```
/home/rfreebern/development/playdoh/vendor/lib/python/django/utils/translation/__init__.py:63: DeprecationWarning: Translations in the project directory aren't supported anymore. Use the LOCALE_PATHS setting instead.
```

This patch eliminates that warning.
