### PR TITLE
Fix DOMAIN_METHODS['messages'] value

### DIFF
--- a/project/settings/base.py
+++ b/project/settings/base.py
@@ -62,7 +62,7 @@ DOMAIN_METHODS['messages'] = [
         'tower.management.commands.extract.extract_tower_template'),
     ('templates/**.html',
         'tower.management.commands.extract.extract_tower_template'),
-],
+]
 
 # # Use this if you have localizable HTML files:
 # DOMAIN_METHODS['lhtml'] = [


### PR DESCRIPTION
With the trailing comma, it becomes a tuple of a list of tuples which
causes babel to be grumpy when you extract strings. Nix the comma and
it becomes a list of tuples and babel is happy.

Tiny r?
