### PR TITLE
always load funfactory from vendor library

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -5,20 +5,16 @@ import sys
 # Edit this if necessary or override the variable in your environment.
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'project.settings')
 
-try:
-    # For local development in a virtualenv:
-    from funfactory import manage
-except ImportError:
-    # Production:
-    # Add a temporary path so that we can import the funfactory
-    tmp_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                            'vendor', 'src', 'funfactory')
-    sys.path.append(tmp_path)
+# Add a temporary path so that we can import the funfactory
+tmp_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                        'vendor', 'src', 'funfactory')
+# Comment out to load funfactory from your site packages instead
+sys.path.insert(0, tmp_path)
 
-    from funfactory import manage
+from funfactory import manage
 
-    # Let the path magic happen in setup_environ() !
-    sys.path.remove(tmp_path)
+# Let the path magic happen in setup_environ() !
+sys.path.remove(tmp_path)
 
 
 manage.setup_environ(__file__, more_pythonic=True)


### PR DESCRIPTION
If funfactory exists in site-packages, it will get imported instead of the
one in vendor-lib. This was intended to be exploited by funfactory devs for
testing new version by installing them in the virtualenv, but it may catch
general developers.

This PR modifies `manage.py` to always load funfactory from vendor-lib. Devs
who want to run a custom funfactory can comment out a single line in
`manage.py` to load it from their virtualenv instead.
