### PR TITLE
load example js correctly with staticfiles

### DIFF
--- a/project/base/templates/example_base.html
+++ b/project/base/templates/example_base.html
@@ -21,7 +21,11 @@
     </div>
 
     {% block site_js %}
-      {{ js('example_js') }}
+      {% compress js %}
+      <script src="{{ static('examples/js/libs/jquery-1.4.4.min.js') }}"></script>
+      <script src="{{ static('examples/js/libs/jquery.cookie.js') }}"></script>
+      <script src="{{ static('examples/js/init.js') }}"></script>
+      {% endcompress %}
     {% endblock %}
   </body>
 </html>


### PR DESCRIPTION
r?

This solves the simple problem that the out-of-the-box playdoh didn't work as pointed out here:
https://github.com/mozilla/playdoh/pull/131
